### PR TITLE
View `SnoopCompile` flamegraph on HTML canvas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /Manifest.toml
 test/flame.html
+test/Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -11,13 +11,14 @@ LeftChildRightSiblingTrees = "1d6d02ad-be62-4b6b-8a6d-2f90e265016e"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[weakdeps]
+SnoopCompile = "aa65fe97-06da-5843-b5b1-d5d13cad87d2"
+
+[extensions]
+SnoopCompileProfileCanvasExt = "SnoopCompile"
 
 [compat]
 JSON = "0.20, 0.21"
 julia = "1"
-
-[extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,9 @@ version = "0.1.6"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+FlameGraphs = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+LeftChildRightSiblingTrees = "1d6d02ad-be62-4b6b-8a6d-2f90e265016e"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"

--- a/ext/SnoopCompileProfileCanvasExt.jl
+++ b/ext/SnoopCompileProfileCanvasExt.jl
@@ -60,7 +60,7 @@ end
 
 """
 Execute `@snoopi_deep` from `SnoopCompile` on the expressionand show the inference tree as 
-a flamegraph as HTML. 
+an HTML flamegraph. 
 """
 macro snoop_view(expr)
     quote

--- a/ext/SnoopCompileProfileCanvasExt.jl
+++ b/ext/SnoopCompileProfileCanvasExt.jl
@@ -1,0 +1,73 @@
+module SnoopCompileProfileCanvasExt
+
+using SnoopCompile
+using SnoopCompile: FlameGraphs
+using ProfileCanvas
+using ProfileCanvas: Node, NodeData, ProfileData, ProfileFrame, ProfileFrameFlag, append_suffix
+import ProfileCanvas: @snoop_view
+
+
+"Frame that is destined to be invisible in the frontend, simulating the type not spent on type inference."
+function emptyframe(count::Int)
+    ProfileFrame("", "", "", 0, count, missing, ProfileFrameFlag.Invisible, missing, ProfileFrame[])
+end
+
+function Base.convert(::Type{ProfileFrame}, node::Node{NodeData})
+    # Fetch information 
+    data_args = nodedata_to_frame_attributes(node.data)
+    # Span is the starting and end count of the node.
+    span = node.data.span
+    i = first(span)
+    # We build recursively build the collection of children.
+    children = ProfileFrame[]
+    for child in node
+        frame = convert(ProfileFrame, child)
+        child_span = child.data.span
+        # If the end time of a child does not match the start of the next,
+        # we add an empty frame with the right span difference.
+        if first(child_span) > i
+            push!(children, emptyframe(first(child_span) - i))
+        end
+        push!(children, frame)
+        i = last(child_span)
+    end
+    ProfileFrame(data_args..., children)
+end
+
+const time_suffixes = ["ns", "μs", "ms", "s"]
+human_time(t_ns) = append_suffix(t_ns, time_suffixes)
+
+"Convert the information of the current node into data that fits `ProfileFrame`."
+function nodedata_to_frame_attributes((; sf, status, span)::NodeData)
+    func = string(sf.func)
+    file = string(sf.file)
+    path = ""
+    line = sf.line
+    count = length(span)
+    countLabel = human_time(length(span))
+    flags = status | ProfileFrameFlag.SnoopCompile
+    tasksID = missing
+    (func, file, path, line, count, countLabel, flags, tasksID)
+end
+
+function view_compile(tinf::SnoopCompile.InferenceTimingNode)
+    fg = flamegraph(tinf)
+    ProfileData(
+        Dict("inference" => convert(ProfileCanvas.ProfileFrame, fg)),
+        "Type inference",
+    )
+end
+
+"""
+Execute `@snoopi_deep` from `SnoopCompile` on the expressionand show the inference tree as 
+a flamegraph as HTML. 
+"""
+macro snoop_view(expr)
+    quote
+        let tinf = @snoopi_deep $(esc(expr))
+            view_compile(tinf)
+        end
+    end
+end
+
+end

--- a/src/ProfileCanvas.jl
+++ b/src/ProfileCanvas.jl
@@ -2,6 +2,9 @@ module ProfileCanvas
 
 using Profile, JSON, REPL, Pkg.Artifacts, Base64
 
+using FlameGraphs: NodeData
+using LeftChildRightSiblingTrees
+
 export @profview, @profview_allocs
 
 struct ProfileData
@@ -20,6 +23,25 @@ mutable struct ProfileFrame
     taskId::Union{Missing,UInt}
     children::Vector{ProfileFrame}
 end
+
+function Base.convert(::Type{ProfileFrame}, node::Node{NodeData})
+    data_args = nodedata_to_frame_attributes(node.data)
+    children = map(child -> convert(ProfileFrame, child), node)
+    ProfileFrame(data_args..., children)
+end
+
+function nodedata_to_frame_attributes((;sf, status, span)::NodeData)
+    func = string(sf.func)
+    file = string(sf.file)
+    path = ""
+    line = sf.line
+    count = length(span)
+    countLabel = missing
+    flags = status
+    tasksID = missing
+    (func, file, path, line, count, countLabel, flags, tasksID)
+end
+
 
 struct ProfileDisplay <: Base.Multimedia.AbstractDisplay end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+SnoopCompile = "aa65fe97-06da-5843-b5b1-d5d13cad87d2"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,26 +1,38 @@
+TestEnv.activate()
 using ProfileCanvas
 using Test
+using SnoopCompile
 
 function profile_test(n)
     for i = 1:n
-        A = randn(100,100,20)
+        A = randn(100, 100, 20)
         m = maximum(A)
         Am = mapslices(sum, A; dims=2)
-        B = A[:,:,5]
+        B = A[:, :, 5]
         Bsort = mapslices(sort, B; dims=1)
         b = rand(100)
-        C = B.*b
+        C = B .* b
     end
 end
 
 @testset "ProfileCanvas.jl" begin
-    trace = @profview profile_test(10)
+    trace = ProfileCanvas.@profview profile_test(10)
     html = sprint(show, "text/html", trace)
     @test occursin("const viewer = new ProfileCanvas.ProfileViewer(", html)
 end
 
 @testset "html file" begin
-    @profview profile_test(10)
-    ProfileCanvas.html_file(joinpath(@__DIR__, "flame.html"))
-    @test isfile(joinpath(@__DIR__, "flame.html"))
+    ProfileCanvas.@profview profile_test(10)
+    path = joinpath(@__DIR__, "flame.html")
+    try
+        ProfileCanvas.html_file(path)
+        @test isfile(joinpath(@__DIR__, "flame.html"))
+    finally
+        isfile(path) && rm(path)
+    end
+end
+
+
+@testset "Snoop view" begin
+    @snoop_view profile_test(10)
 end


### PR DESCRIPTION
Closes https://github.com/pfitzseb/ProfileCanvas.jl/issues/33

This is non-trivial MR which:
- Adds a conversion from the Flamegraph type from [FlameGraphs.jl](https://github.com/timholy/FlameGraphs.jl) to the ProfileFrame defined here.
- Creates a package extension on [SnoopCompile.jl](https://github.com/timholy/SnoopCompile.jl) and add the `@snoop_view` macro which run `@snoopi_deep` on an expression and returns a ProfileCanvas HTML flamegraph
- For this MR to work nicely https://github.com/pfitzseb/jl-profile.js/pull/1 is required to be merged.